### PR TITLE
Refresh public project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,59 @@
-<p align="center">
-  <a href="" rel="noopner">
-    <img height=200px src="http://cdn.differencebetween.net/wp-content/uploads/2018/05/Difference-Between-Link-and-Hyperlink.png" alt="Hire Chain Logo"></a>
+﻿# HireChain
 
-<h1 align="center">HireChain</h1>
-<h4>An open platform for job openings and acceptance in various tech and non-tech fields. (Freelancing)</h4>
+HireChain is a marketplace prototype for hiring and project delivery. It combines an Express and MongoDB backend, an IPFS integration path, a Solidity contract, and a React client.
 
-------------------------------------------
-### Research Paper
+## Repository Status
 
-<a href="https://www.irjet.net/archives/V6/i9/IRJET-V6I9344.pdf" target="_blank">Decentralized Freelancing System - Trust and Transparency</a>
-  
-------------------------------------------
-### Objectives
+- Current role: Decentralized work marketplace prototype connecting project work, delivery evidence, and blockchain settlement concepts
+- Documentation status: refreshed for public review
+- Primary audience: engineers, product reviewers, and collaborators evaluating the project context
 
-~`Fairness`: Direct employee to employer contact, no middleman.<br/>
-~`Security`: Employer has to pay for the work done. Employee is also bind by the contract to complete work<br/>
-~`Identity Protection`: No identity confirmation required.<br/>
-~`Direct Payment`: Payment via ethereum wallet.<br/>
-~`Limited T&C`: Social media and personal data sharing is banned.<br/>
-~`Transparency`
+## What This Project Does
 
+- Express backend for marketplace workflows
+- MongoDB-backed application state
+- IPFS integration path for delivery artifacts
+- Solidity contract for marketplace settlement concepts
+- React client under the Client directory
 
-------------------------------------------
-### Features
+## Technology Stack
 
--`Post project`:  Add your projects to the network so that other users can apply.<br/>
--`Apply for project`: You can apply for the available projects.<br/>
--`Bidding`: You can bid for the project and accordingly the project will be alloted.<br/>
--`Contract`: While acceptance of the project contract will be made between the employee and the employer.<br/>
+- Node.js, Express, and MongoDB
+- React frontend client
+- IPFS HTTP client
+- Solidity smart contract
+- concurrently and nodemon for development scripts
 
-------------------------------------------
-### Demo
+## Repository Map
 
-<p align="center">
-<img src ="./demo.gif" max-width = 600px>
-</p>
+- app.js is the backend entry point
+- models.js contains data model definitions
+- HireChain.sol captures the contract concept
+- Client/ contains the frontend application
 
-------------------------------------------
-### Installation
-  * Step I: Clone the Repository
-```sh
-      $ git clone https://github.com/priyamshah112/HireChain.git      
-```
-  * Step II: Install server packages
-```sh
-      # On the terminal move into HireChain package directory
-      $ cd HireChain
-      $ npm install
-```
-* Step III: Install client packages
-```sh
-      # Open another terminal and move into Client package directory
-      $ cd Client
-      $ npm install
-```
-* Step IV: Run Server
-```sh
-      # Run server on the first terminal
-      $ nodemon app
-```
+## Getting Started
 
-* Step V: Run Client
-```sh
-      # Run client on the second terminal
-      $ npm start
-```
+- Install Node.js and npm
+- Run npm install at the repository root
+- Install client dependencies under Client if needed
+- Configure local database and IPFS values with safe placeholders
+- Run npm run server, npm run client, or npm start depending on the workflow being tested
+
+## Documentation
+
+- docs/overview.md - product context, users, scope, and outcomes
+- docs/architecture.md - components, data flow, and sequence diagrams
+- docs/product.md - user journeys, requirements, constraints, and roadmap ideas
+- docs/operations.md - setup, validation, maintenance, and known risks
+
+## Known Limitations
+
+- Contract and IPFS paths need dedicated tests before production use
+- Marketplace dispute handling is a product and governance problem, not only a code problem
+- The existing prototype should be modernized before any live funds or sensitive data are involved
+
+## Notes For Future Maintainers
+
+This repository documents the original project intent and the implementation shape visible in the codebase. Before production use, review dependencies, environment configuration, data handling, and deployment assumptions against current standards.
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,45 @@
+﻿# Architecture
+
+HireChain combines a conventional marketplace app with decentralized trust primitives. The web application handles workflow, MongoDB tracks application state, IPFS can hold delivery evidence, and a Solidity contract represents settlement logic.
+
+## Component View
+
+```mermaid
+flowchart LR
+  Actor["Client or freelancer"] --> Entry["React client and Express API"]
+  Entry --> Service["Marketplace workflow service"]
+  Service --> Data["MongoDB and IPFS references"]
+  Service --> External["Solidity contract and IPFS node"]
+```
+
+## Key Components
+
+- Express API and route handlers
+- MongoDB model layer
+- React client application
+- IPFS integration path
+- HireChain Solidity contract
+
+## Main Workflow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Client
+  participant App
+  participant Store
+  User->>Client: Posts work or submits delivery evidence
+  Client->>App: Sends marketplace action to API
+  App->>Store: Validate and persist state
+  Store-->>App: Work state and evidence reference saved
+  App-->>Client: Returns updated marketplace status
+  Client-->>User: Present updated result
+```
+
+## Design Considerations
+
+- Keep delivery evidence distinct from marketplace status
+- Avoid making blockchain interactions invisible to users
+- Design dispute and review flows before adding settlement automation
+
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,31 @@
+﻿# Operations
+
+These notes capture the practical work needed to run, maintain, or modernize the repository from its current state.
+
+## Local Operation
+
+- Install Node.js and npm
+- Run npm install at the repository root
+- Install client dependencies under Client if needed
+- Configure local database and IPFS values with safe placeholders
+- Run npm run server, npm run client, or npm start depending on the workflow being tested
+
+## Validation
+
+- Run npm test if implemented
+- Smoke-test server and client separately
+- Test contract behavior on a local chain only
+
+## Maintenance Notes
+
+- Review IPFS and Solidity dependencies
+- Document local setup and example flows
+- Avoid committing generated client builds
+
+## Operational Risks
+
+- Contract and IPFS paths need dedicated tests before production use
+- Marketplace dispute handling is a product and governance problem, not only a code problem
+- The existing prototype should be modernized before any live funds or sensitive data are involved
+
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,27 @@
+﻿# Overview
+
+The project explores how freelance marketplace trust could be improved by connecting job workflows, proof of delivery, and settlement logic.
+
+## Problem Space
+
+Freelance marketplaces depend on trust between clients and workers. A decentralized design can make delivery evidence and settlement decisions more transparent, but only if the user workflow remains simple.
+
+## Primary Users
+
+- Clients posting work
+- Freelancers delivering work
+- Marketplace operators resolving trust and settlement issues
+
+## Scope
+
+- Work listing, delivery evidence, and settlement concepts
+- Backend and frontend prototype structure
+- Decentralized storage and contract integration exploration
+
+## Outcomes To Evaluate
+
+- The trust model is legible
+- Proof-of-delivery workflow can be explained to non-technical readers
+- Modernization needs are clearly visible
+
+

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,29 @@
+﻿# Product Notes
+
+The product idea is a trust-centered work marketplace: clients need confidence in delivery, freelancers need fair settlement, and both sides need clear state.
+
+## User Journeys
+
+- Client posts a work request and reviews submissions
+- Freelancer accepts work and attaches delivery evidence
+- Marketplace logic records progress toward settlement
+
+## Functional Requirements
+
+- Track work, participants, and delivery state
+- Attach evidence references without overloading the database
+- Represent settlement state transparently
+
+## Constraints
+
+- Blockchain transactions introduce latency and cost
+- IPFS evidence needs availability planning
+- Disputes require human and policy design
+
+## Roadmap Ideas
+
+- Add contract and API tests
+- Separate marketplace domain logic from Express handlers
+- Document dispute, escrow, and evidence policies
+
+


### PR DESCRIPTION
## Summary
- Refresh the public README with a neutral project overview, stack, setup notes, and limitations.
- Add standard documentation under docs/ where useful: overview, architecture, product, and operations.
- Keep the content professional and repository-focused without strategy-specific document names.

## Validation
- Documentation-only change.
- Verified README docs links locally across the refresh batch.